### PR TITLE
unprotect main branch so stray akka commit can be removed

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -19,8 +19,7 @@ github:
     merge:   false
     rebase:  true
 
-  protected_branches:
-    main: { }
+  protected_branches: ~
 
 notifications:
   commits:              commits@pekko.apache.org


### PR DESCRIPTION
A commit was copied over from akka in error - https://github.com/apache/incubator-pekko-platform-guide/commit/b01199faac7950c8ed922d19ff30284867c6822e 

Tidiest to remove it from branch and reapply newer commits.